### PR TITLE
bokeh 2.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,13 @@ requirements:
     - wheel
   run:
     - python
-    - pyyaml >=3.10
-    - python-dateutil >=2.1
     - jinja2 >=2.9
     - numpy >=1.11.3
-    - pillow >=7.1.0
     - packaging >=16.8
+    - pillow >=7.1.0
+    - pyyaml >=3.10
     - tornado >=5.1
-    - typing_extensions >=3.7.4
+    - typing_extensions >=3.10.0
 
 test:
   imports:


### PR DESCRIPTION
Update bokeh to 2.4.1

Category:  anaconda | subcategory:  core | pkg_type:  python
Popularity:  5793590 downloads -  bokeh  2.4.1  Statistical and novel interactive HTML plots for Python
Version change: bump version number from 2.3.3 to 2.4.1
  license: BSD-3-Clause
Release date:  Oct 13, 2021
License : https://github.com/bokeh/bokeh/blob/branch-2.4/LICENSE.txt
Changelog: https://github.com/bokeh/bokeh/blob/branch-2.4/CHANGELOG
Upstream Issues: https://github.com/bokeh/bokeh/issues
Requirements: https://github.com/bokeh/bokeh/blob/2.4.1/setup.py and https://github.com/bokeh/bokeh/blob/2.4.1/_setup_support.py

The package bokeh is mentioned inside the packages:
bkcharts | colorcet | dask | datashader | geoviews | geoviews-core | holoviews | hvplot | neon | panel |

Actions:
1. Update and sort dependencies

Result:
- all-succeeded