### PR TITLE
bokeh 2.4.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,6 @@ build:
     - bokeh = bokeh.__main__:main
 
 requirements:
-  build:
-    - python                                 # [build_platform != target_platform]
   host:
     - python
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2.4.1" %}
+{% set version = "2.4.2" %}
 
 package:
   name: bokeh
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/b/bokeh/bokeh-{{ version }}.tar.gz
-  sha256: d0410717d743a0ac251e62480e2ea860a7341bdcd1dbe01499a904f233c90512
+  sha256: f0a4b53364ed3b7eb936c5cb1a4f4132369e394c7ae0a8ef420459410958033d
 
 build:
   number: 0


### PR DESCRIPTION
Update bokeh to 2.4.2

Version change: bump version number from 2.4.1 to 2.4.2
Bug Tracker: new open issues http://github.com/bokeh/bokeh/issues
Upstream Changelog: http://github.com/bokeh/bokeh/blob/master/CHANGELOG
Requirements: https://github.com/bokeh/bokeh/blob/2.4.2/setup.py and https://github.com/bokeh/bokeh/blob/2.4.2/_setup_support.py

The package bokeh is mentioned inside the packages:
bkcharts | colorcet | dask | datashader | geoviews | geoviews-core | holoviews | hvplot | neon | panel |

Actions:
1. Remove the `build ` section

Result:
- all-succeeded