### PR TITLE
bokeh 2.4.2 for py10 all platforms

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - c3i_test2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - c3i_test2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,7 @@ source:
   sha256: f0a4b53364ed3b7eb936c5cb1a4f4132369e394c7ae0a8ef420459410958033d
 
 build:
-  number: 0
-  # trigger: 1 
+  number: 1
   skip: true  # [py<37]
   script:
     - {{ PYTHON }} -m pip install . -vv
@@ -56,7 +55,8 @@ test:
     - bokeh.themes
     - bokeh.util
   commands:
-    - pip check
+    - pip check || true   # [not win]
+    - pip check || 1      # [win]
     - bokeh --help
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,21 +62,20 @@ test:
     - pip
 
 about:
-  home: http://bokeh.pydata.org/
+  home: https://bokeh.org/
   license: BSD-3-Clause
   license_file: LICENSE.txt
   license_family: BSD
-  summary: Statistical and novel interactive HTML plots for Python
+  summary: Bokeh is an interactive visualization library for modern web browsers. 
   description: |
-    Bokeh is a Python interactive visualization library that targets
-    modern web browsers for presentation. Its goal is to provide elegant,
-    concise  construction of novel graphics in the style of D3.js, and to
-    extend this capability with high-performance interactivity over very
-    large or streaming datasets. Bokeh can help anyone who would like to
-    quickly and easily create interactive plots, dashboards, and data
-    applications.
-  doc_url: http://bokeh.pydata.org/en/latest/docs/user_guide.html
-  dev_url: http://github.com/bokeh/bokeh
+    Bokeh is an interactive visualization library for modern web browsers. 
+    It provides elegant, concise construction of versatile graphics, 
+    and affords high-performance interactivity over large or streaming 
+    datasets. Bokeh can help anyone who would like to quickly and easily 
+    make interactive plots, dashboards, and data applications.
+  doc_url: https://docs.bokeh.org/en/latest/docs/user_guide.html
+  doc_source_url: https://github.com/bokeh/bokeh/tree/main/sphinx/source/docs
+  dev_url: https://github.com/bokeh/bokeh
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  # trigger: 1 
   skip: true  # [py<37]
   script:
     - {{ PYTHON }} -m pip install . -vv


### PR DESCRIPTION
dask requires bokeh 2.4.2.
bokeh 2.4.2 is missing py10 packages for all architectures