### PR TITLE
bokeh 3.0.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bokeh" %}
-{% set version = "3.0.1" %}
+{% set version = "3.0.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bokeh-{{ version }}.tar.gz
-  sha256: aa044829f66f08e9aeb74e33d538bc719270406124ea128bd7616e09e1561815
+  sha256: fb537cf24f5a25a6739393f9906ddf8c913bfebc4cb120d342e8262889326f7d
 
 build:
   number: 0
@@ -23,7 +23,7 @@ requirements:
     - python
     - colorama
     - pip
-    - setuptools >=64
+    - setuptools
     # Should be setuptools-git-versioning <2, see https://github.com/dolfinus/setuptools-git-versioning#pyprojecttoml
     - setuptools-git-versioning <2
     - wheel
@@ -74,7 +74,6 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
-  license_url: https://github.com/bokeh/bokeh/blob/main/LICENSE.txt
   summary: Bokeh is an interactive visualization library for modern web browsers. 
   description: |
     Bokeh is an interactive visualization library for modern web browsers. 
@@ -83,7 +82,6 @@ about:
     datasets. Bokeh can help anyone who would like to quickly and easily 
     make interactive plots, dashboards, and data applications.
   doc_url: https://docs.bokeh.org
-  doc_source_url: https://github.com/bokeh/bokeh/tree/main/docs/bokeh/source
   dev_url: https://github.com/bokeh/bokeh
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   number: 0
   # Currently xyzservices >=2021.09.1 is not available on s390x
   skip: true  # [py<38 or s390x]
-  script: 
+  script:
     - {{ PYTHON }} -m pip install . -vv
   entry_points:
     - bokeh = bokeh.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,19 +1,18 @@
-{% set version = "2.4.3" %}
+{% set name = "bokeh" %}
+{% set version = "3.0.1" %}
 
 package:
-  name: bokeh
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/b/bokeh/bokeh-{{ version }}.tar.gz
-  sha256: ef33801161af379665ab7a34684f2209861e3aefd5c803a21fbbb99d94874b03
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bokeh-{{ version }}.tar.gz
+  sha256: aa044829f66f08e9aeb74e33d538bc719270406124ea128bd7616e09e1561815
 
 build:
   number: 0
-  # trigger: 1
-  skip: true  # [py<37]
-  script:
-    - {{ PYTHON }} -m pip install . -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . -vv
   entry_points:
     - bokeh = bokeh.__main__:main
 
@@ -26,12 +25,15 @@ requirements:
   run:
     - python
     - jinja2 >=2.9
+    - contourpy >=1
     - numpy >=1.11.3
     - packaging >=16.8
+    - pandas >=1.2
     - pillow >=7.1.0
     - pyyaml >=3.10
     - tornado >=5.1
     - typing_extensions >=3.10.0
+    - xyzservices >=2021.09.1
 
 test:
   imports:
@@ -55,18 +57,19 @@ test:
     - bokeh.sphinxext
     - bokeh.themes
     - bokeh.util
-  commands:
-    - pip check || true   # [not win]
-    - pip check || 1      # [win]
-    - bokeh --help
   requires:
     - pip
+  commands:
+    - pip check || true   # [not win]
+    - pip check || (exit 1)  # [win]
+    - bokeh --help
 
 about:
   home: https://bokeh.org/
   license: BSD-3-Clause
-  license_file: LICENSE.txt
   license_family: BSD
+  license_file: LICENSE.txt
+  license_url: https://github.com/bokeh/bokeh/blob/main/LICENSE.txt
   summary: Bokeh is an interactive visualization library for modern web browsers. 
   description: |
     Bokeh is an interactive visualization library for modern web browsers. 
@@ -74,8 +77,8 @@ about:
     and affords high-performance interactivity over large or streaming 
     datasets. Bokeh can help anyone who would like to quickly and easily 
     make interactive plots, dashboards, and data applications.
-  doc_url: https://docs.bokeh.org/en/latest/docs/user_guide.html
-  doc_source_url: https://github.com/bokeh/bokeh/tree/main/sphinx/source/docs
+  doc_url: https://docs.bokeh.org
+  doc_source_url: https://github.com/bokeh/bokeh/tree/main/docs/bokeh/source
   dev_url: https://github.com/bokeh/bokeh
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,16 +11,20 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<38]
-  script: {{ PYTHON }} -m pip install . -vv
+  # Currently xyzservices >=2021.09.1 is not available on s390x
+  skip: true  # [py<38 or s390x]
+  script: 
+    - {{ PYTHON }} -m pip install .
   entry_points:
     - bokeh = bokeh.__main__:main
 
 requirements:
   host:
     - python
+    - colorama
     - pip
-    - setuptools
+    - setuptools >=64
+    - setuptools-git-versioning
     - wheel
   run:
     - python
@@ -32,7 +36,6 @@ requirements:
     - pillow >=7.1.0
     - pyyaml >=3.10
     - tornado >=5.1
-    - typing_extensions >=3.10.0
     - xyzservices >=2021.09.1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@ test:
     - pip
   commands:
     - pip check || true   # [not win]
-    - pip check || (exit 1)  # [win]
+    - pip check || cmd /K "exit /b 0"  # [win]
     - bokeh --help
     - bokeh info
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   # Currently xyzservices >=2021.09.1 is not available on s390x
   skip: true  # [py<38 or s390x]
   script: 
-    - {{ PYTHON }} -m pip install .
+    - {{ PYTHON }} -m pip install . -vv
   entry_points:
     - bokeh = bokeh.__main__:main
 
@@ -24,7 +24,8 @@ requirements:
     - colorama
     - pip
     - setuptools >=64
-    - setuptools-git-versioning
+    # Should be setuptools-git-versioning <2, see https://github.com/dolfinus/setuptools-git-versioning#pyprojecttoml
+    - setuptools-git-versioning <2
     - wheel
   run:
     - python
@@ -66,6 +67,7 @@ test:
     - pip check || true   # [not win]
     - pip check || (exit 1)  # [win]
     - bokeh --help
+    - bokeh info
 
 about:
   home: https://bokeh.org/


### PR DESCRIPTION
**Jira ticket:** [PKG-654](https://anaconda.atlassian.net/browse/PKG-654) (bokeh-3.0.*)

**The upstream data:**
Releases:  https://docs.bokeh.org/en/latest/docs/releases.html
[Diff between the latest and previous upstream releases](https://github.com/bokeh/bokeh/compare/2.4.3...3.0.2)
Requirements:
 * setup.py:  https://github.com/bokeh/bokeh/blob/3.0.2/setup.py
 * pyproject.toml:  https://github.com/bokeh/bokeh/blob/3.0.2/pyproject.toml

**_Actions:_**

1. Skip `py<38` and `s390x`
2. Add `colorama` and `setuptools-git-versioning` to `host`
3. Update run dependencies: add `contourpy`, pandas, and `xyzservices` to `run`; remove `typing_extensions`
4. Fix `pip check`
5. Add `bokeh info` command
6. Update `doc_url`
7. Remove `doc_source_url`

**_Notes:_**
 * Downstream packages `datashader` 0.14.1 b1 & 0.14.2 and `holoviews` 0.15.0 & 0.15.2 already have the upper bound **<3.0.0**  for `bokeh` 

**Package's statistics**
<details>

 * Priority B | effort: medium | Category: anaconda | subcategory: core | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 3.0.1
 * Release on PyPi:
    * version: 3.0.2
    * date: 2022-11-14T19:54:19
* [PyPi history](https://pypi.org/project/bokeh/#history)
 * Popularity: 
    * 3 months downloads: 901887.0
    * All time:  9214601 downloads -  bokeh  3.0.2  Statistical and novel interactive HTML plots for Python  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/bokeh/bokeh/tree/3.0.1 exists
8. - [x] https://bokeh.org/ is present
9. - [x] Check the pinnings
10. - [x] Additional research
    https://github.com/bokeh/bokeh/issues
    200
11. - [x] `dev_url` is present
    https://github.com/bokeh/bokeh
12. - [x] Verify that the `build_number` is correct
13. - [x] Verify if the package needs `setuptools`
14. - [x] has `wheel`
15. - [x] `pip` in test
16. - [x] Verify the test section
17. - [x] Verify if the package is `architecture specific`
18. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
19.  - [x] license_file: LICENSE.txt is present
20. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

21. - [x] license_family BSD is present
</details>

