### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bokeh" %}
-{% set version = "3.3.4" %}
+{% set version = "3.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bokeh-{{ version }}.tar.gz
-  sha256: 73b7982dc2b8df15bf660cdddc8d3825e829195c438015a5d09824f1a7028368
+  sha256: 9ea6bc407b5e7d04ba7a2f07d8f00e8b6ffe02c2368e707f41bb362a9928569a
 
 build:
   number: 0
@@ -28,13 +28,13 @@ requirements:
   run:
     - python
     - jinja2 >=2.9
-    - contourpy >=1
+    - contourpy >=1.2
     - {{ pin_compatible('numpy') }}
     - packaging >=16.8
     - pandas >=1.2
     - pillow >=7.1.0
     - pyyaml >=3.10
-    - tornado >=5.1
+    - tornado >=6.2
     - xyzservices >=2021.09.1
 
 test:


### PR DESCRIPTION
bokeh 3.4.0

**Destination channel:** defaults

### Explanation of changes:

Bumps version to 3.4.0 and updates version pins to match bokeh [`pyproject.toml`](https://github.com/bokeh/bokeh/blob/3.4.0/pyproject.toml#L11)