### PR TITLE
Release 3.5.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bokeh" %}
-{% set version = "3.4.1" %}
+{% set version = "3.4.3" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bokeh-{{ version }}.tar.gz
-  sha256: d824961e4265367b0750ce58b07e564ad0b83ca64b335521cd3421e9b9f10d89
+  sha256: b7c22fb0f7004b04f12e1b7b26ee0269a26737a08ded848fb58f6a34ec1eb155
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bokeh" %}
-{% set version = "3.4.3" %}
+{% set version = "3.5.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bokeh-{{ version }}.tar.gz
-  sha256: b7c22fb0f7004b04f12e1b7b26ee0269a26737a08ded848fb58f6a34ec1eb155
+  sha256: 03a54a67db677b8881834271c620a781b383ae593af5c3ea2149164754440d07
 
 build:
   number: 0
-  skip: true  # [py<39]
+  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - bokeh = bokeh.__main__:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -51,7 +51,6 @@ test:
     - bokeh.models
     - bokeh.models.widgets
     - bokeh.plotting
-    - bokeh.sampledata
     - bokeh.server
     - bokeh.protocol
     - bokeh.protocol.messages


### PR DESCRIPTION
bokeh 3.5.2

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/bokeh/bokeh)
- [Upstream changelog/diff](https://github.com/bokeh/bokeh/compare/3.4.3...3.5.2#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711)

### Explanation of changes:

- Python 3.9 dropped
- Bokeh 3.5 no longer ships with sample data and instead relies on an external package `bokeh_sampledata`. As a consequence, I removed the test `import bokeh.sampledata`, like it was done on conda-forge https://github.com/conda-forge/bokeh-feedstock/pull/103/files.
