### PR TITLE
Release 3.6.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bokeh" %}
-{% set version = "3.6.0" %}
+{% set version = "3.6.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/bokeh-{{ version }}.tar.gz
-  sha256: 0032dc1e76ad097b07626e51584685ff48c65481fbaaad105663b1046165867a
+  sha256: 2f3043d9ecb3d5dc2e8c0ebf8ad55727617188d4e534f3e7208b36357e352396
 
 build:
   number: 0


### PR DESCRIPTION
bokeh 3.6.2

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/bokeh/bokeh)
- [Upstream changelog/diff](https://docs.bokeh.org/en/latest/docs/releases.html#release-3-6-2)

### Explanation of changes:

- Simple version upgrade
